### PR TITLE
ソーシャルログイン機能の見直し

### DIFF
--- a/api/app/controllers/api/v1/oauth/googles_controller.rb
+++ b/api/app/controllers/api/v1/oauth/googles_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::Oauth::GooglesController < ApplicationController
       user_info = JSON.parse(response.body)
 
       if user_info["email"]
-        user = User.find_or_create_from_oauth(
+        user = Authentication.find_or_create_user_from_oauth(
           'google',
           user_info["sub"],
           user_info["name"],
@@ -29,7 +29,7 @@ class Api::V1::Oauth::GooglesController < ApplicationController
           user_info["picture"]
         )
 
-        if user.valid?
+        if user && user.valid?
           refresh_token = user.refresh_me!
           set_refresh_token_to_cookie(refresh_token)
         else

--- a/api/app/controllers/api/v1/oauth/twitters_controller.rb
+++ b/api/app/controllers/api/v1/oauth/twitters_controller.rb
@@ -46,8 +46,8 @@ class Api::V1::Oauth::TwittersController < ApplicationController
     when Net::HTTPSuccess
       user_info = JSON.parse(response.body)
 
-      if user_info["email"]
-        user = User.find_or_create_from_oauth(
+      if user_info["id"]
+        user = Authentication.find_or_create_user_from_oauth(
           'twitter',
           user_info["id"],
           user_info["name"],
@@ -55,7 +55,7 @@ class Api::V1::Oauth::TwittersController < ApplicationController
           user_info["profile_image_url_https"].sub('normal', 'bigger')
         )
 
-        if user.valid?
+        if user && user.valid?
           refresh_token = user.refresh_me!
           set_refresh_token_to_cookie(refresh_token)
         else

--- a/api/app/controllers/api/v1/oauth/yahoos_controller.rb
+++ b/api/app/controllers/api/v1/oauth/yahoos_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Oauth::YahoosController < ApplicationController
       user_info = JSON.parse(response.body)
 
       if user_info["email"]
-        user = User.find_or_create_from_oauth(
+        user = Authentication.find_or_create_user_from_oauth(
           'yahoo',
           user_info["sub"],
           user_info["nickname"],
@@ -28,7 +28,7 @@ class Api::V1::Oauth::YahoosController < ApplicationController
           user_info["picture"]
         )
 
-        if user.valid?
+        if user && user.valid?
           refresh_token = user.refresh_me!
           set_refresh_token_to_cookie(refresh_token)
         else

--- a/api/app/models/authentication.rb
+++ b/api/app/models/authentication.rb
@@ -1,0 +1,28 @@
+class Authentication < ApplicationRecord
+  mount_uploader :image, AvatarUploader
+  belongs_to :user
+
+  def self.find_or_create_user_from_oauth(provider, uid, name, email, image)
+    (
+      Authentication.find_or_create_by(provider: provider, uid: uid) do |authentication|
+        authentication.remote_image_url = image
+        user = authentication.build_user
+        random_value = SecureRandom.alphanumeric(10)
+
+        # twitterはメールアドレスが登録されていないこともあるため、ダミーのメールアドレスをセットする
+        if provider == 'twitter'
+          email = "#{provider}_#{uid}@mail.ondoku-star.com"
+          user.email_status = 'unset'
+        end
+
+        user.name = name
+        user.email = email
+        user.avatar = authentication.image.filename
+        user.password = random_value
+        user.password_confirmation = random_value
+      end
+    ).user
+  rescue StandardError
+    nil
+  end
+end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,13 +1,13 @@
 class User < ApplicationRecord
   include AccessToken
   include RefreshToken
-  mount_uploader :oauth_avatar, AvatarUploader
   authenticates_with_sorcery!
 
   has_many :sentences, as: :creater, dependent: :destroy
   has_many :trainings, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_sentences, through: :bookmarks, source: :sentence
+  has_many :authentications, dependent: :destroy
 
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 50 }
 
+  enum email_status: { unverified: 0, verified: 1, unset: 2 }
   enum role: { general: 0, admin: 1, guest: 2 }
   enum listening_sex: { female: 0, male: 1 }
 

--- a/api/app/resources/user_resource.rb
+++ b/api/app/resources/user_resource.rb
@@ -3,6 +3,6 @@ class UserResource
 
   root_key :user, :users
 
-  attributes :id, :email, :name, :avatar, :listening_sex, :created_at, :updated_at
+  attributes :id, :email, :email_status, :name, :avatar, :listening_sex, :created_at, :updated_at
   transform_keys :lower_camel
 end

--- a/api/app/uploaders/avatar_uploader.rb
+++ b/api/app/uploaders/avatar_uploader.rb
@@ -10,7 +10,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "public/#{ENV['RAILS_ENV']}/uploads/#{model.class.to_s.underscore}/avatar/#{model.id}"
+    "public/#{ENV['RAILS_ENV']}/uploads/user/avatar/#{model.user.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/api/db/migrate/20220901223117_create_authentications.rb
+++ b/api/db/migrate/20220901223117_create_authentications.rb
@@ -1,0 +1,14 @@
+class CreateAuthentications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :authentications do |t|
+      t.string :uid
+      t.string :provider
+      t.string :image
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :authentications, [:provider, :uid], unique: true
+  end
+end

--- a/api/db/migrate/20220901223511_remove_uidprovide_from_users.rb
+++ b/api/db/migrate/20220901223511_remove_uidprovide_from_users.rb
@@ -1,0 +1,8 @@
+class RemoveUidprovideFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :users, column: [:provider, :uid], unique: true
+    remove_column :users, :uid, :string
+    remove_column :users, :provider, :string
+    remove_column :users, :oauth_avatar, :string
+  end
+end

--- a/api/db/migrate/20220902072414_add_emailstatus_to_users.rb
+++ b/api/db/migrate/20220902072414_add_emailstatus_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailstatusToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :email_status, :integer, null: false, default: 0
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_01_212425) do
+ActiveRecord::Schema.define(version: 2022_09_02_072414) do
+
+  create_table "authentications", charset: "utf8mb4", force: :cascade do |t|
+    t.string "uid"
+    t.string "provider"
+    t.string "image"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid", unique: true
+    t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
 
   create_table "bookmarks", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -79,24 +90,22 @@ ActiveRecord::Schema.define(version: 2022_09_01_212425) do
     t.string "name", null: false
     t.string "avatar"
     t.integer "role", default: 0, null: false
-    t.string "provider"
-    t.string "uid"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "refresh_token"
     t.datetime "refresh_token_expires_at"
-    t.string "oauth_avatar"
     t.string "reset_password_token"
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.integer "listening_sex", default: 0, null: false
+    t.integer "email_status", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["refresh_token"], name: "index_users_on_refresh_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "authentications", "users"
   add_foreign_key "bookmarks", "sentences"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "news", "news_categories"

--- a/front/src/components/pages/profile/index.vue
+++ b/front/src/components/pages/profile/index.vue
@@ -16,7 +16,7 @@
         <div class="text-center mt-4">
           <p class="text-subtitle-1 fs-small text-grey-darken-3">メールアドレス</p>
           <v-divider length="110" thickness="2" color="silver mt-n1" class="mx-auto"></v-divider>
-          <p class="mt-2 text-body-1">{{ currentUser.email }}</p>
+          <p class="mt-2 text-body-1">{{ currentUserEmail }}</p>
         </div>
         <div class="text-center mt-5">
           <v-btn 
@@ -333,6 +333,14 @@ const buttonWidth: ComputedRef<string | number | undefined> = computed(() => {
     return '100%'
   } else {
     return undefined
+  }
+})
+
+const currentUserEmail: ComputedRef<string> = computed(() => {
+  if(currentUser.emailStatus === "unset"){
+    return "設定されていません"
+  } else {
+    return currentUser.email
   }
 })
 

--- a/front/src/store/userStore.ts
+++ b/front/src/store/userStore.ts
@@ -3,6 +3,7 @@ import { defineStore } from "pinia"
 interface User {
   id: number
   email: string
+  emailStatus: "unverified" | "verified" | "unset"
   name: string
   avatar: string
   listeningSex: "male" | "female" | undefined


### PR DESCRIPTION
close #72 
## 内容
ソーシャルログイン機能の仕様を以下のよう変更しました。
twitterログインではメールアドレスを取得しないよう変更（twitterは全てのユーザーがメールアドレスを設定しているわけではないため）
Authenticationモデルを作成し、providerとuidはAuthenticationで管理する(拡張性を考慮)